### PR TITLE
[objects] Add padding to JSArrayBuffer for CHERI architectures

### DIFF
--- a/src/objects/js-array-buffer.tq
+++ b/src/objects/js-array-buffer.tq
@@ -24,6 +24,12 @@ extern class JSArrayBuffer extends JSObjectWithEmbedderSlots {
   // Pads header size to be a multiple of kTaggedSize.
   @if(TAGGED_SIZE_8_BYTES) optional_padding: uint32;
   @ifnot(TAGGED_SIZE_8_BYTES) optional_padding: void;
+  @if(CHERI_PURECAP_UNCOMPRESSED) optional_padding_one: uint32;
+  @if(CHERI_PURECAP_UNCOMPRESSED) optional_padding_two: uint32;
+  @if(CHERI_PURECAP_UNCOMPRESSED) optional_padding_three: uint32;
+  @ifnot(CHERI_PURECAP_UNCOMPRESSED) optional_padding_one: void;
+  @ifnot(CHERI_PURECAP_UNCOMPRESSED) optional_padding_two: void;
+  @ifnot(CHERI_PURECAP_UNCOMPRESSED) optional_padding_three: void;
 }
 
 extern operator '.byte_length' macro LoadJSArrayBufferByteLength(JSArrayBuffer):


### PR DESCRIPTION
This fixes the v8 CHERI bug that was found by fuzzilli:

```
Core was generated by `/home/zyj20/v8/out/cheri-uncompressed-fuzz/d8'.
Program terminated with signal SIGSEGV, Segmentation fault.
Sent by thr_kill() from pid 51843 and user 1001.
#0  VisitHeapObjectImpl<v8::internal::FullObjectSlot> () at ../../src/heap/scavenger-inl.h:509

warning: 509    ../../src/heap/scavenger-inl.h: No such file or directory
[Current thread is 1 (LWP 223438)]
gef>  bt
#0  VisitHeapObjectImpl<v8::internal::FullObjectSlot> () at ../../src/heap/scavenger-inl.h:509
#1  VisitPointersImpl<v8::internal::FullObjectSlot> () at ../../src/heap/scavenger-inl.h:523
#2  VisitPointers () at ../../src/heap/scavenger-inl.h:499
#3  IteratePointers<v8::internal::ScavengeVisitor> () at ../../src/objects/objects-body-descriptors-inl.h:147
#4  IterateJSObjectBodyImpl<v8::internal::ScavengeVisitor> () at ../../src/objects/objects-body-descriptors-inl.h:131
#5  IterateBody<v8::internal::ScavengeVisitor> () at ../../src/objects/objects-body-descriptors-inl.h:418
#6  VisitJSArrayBuffer () at ../../src/heap/scavenger-inl.h:531
#7  Visit () at ../../src/heap/objects-visiting-inl.h:128
#8  Visit () at ../../src/heap/objects-visiting-inl.h:116
#9  Process () at ../../src/heap/scavenger.cc:719
#10 0x0000000000c004a0 in ProcessItems () at ../../src/heap/scavenger.cc:226
#11 0x0000000000c00278 in Run () at ../../src/heap/scavenger.cc:205
#12 0x0000000000904fa4 in Run () at ../../src/libplatform/default-job.h:147
#13 0x000000000090a71c in Run () at ../../src/libplatform/default-worker-threads-task-runner.cc:73
#14 0x0000000000900470 in NotifyStartedAndRun () at ../../src/base/platform/platform.h:605
#15 ThreadEntry () at ../../src/base/platform/platform-posix.cc:1222
#16 0x0000000041e2ee68 in thread_start (curthread=0x42c1f400 [rwRW,0x42c1f400-0x42c1fe00])
    at /usr/src/lib/libthr/thread/thr_create.c:347
#17 0x0000000000000000 in ?? ()
```

This can be reproduced using `./d8 --random_seed 1 --expose_gc --max-old-space-size=20 --max-semi-space-size=1 poc.js`.

```js
function allocateSurvivor() {
  // 100 KB typed‐array that we'll keep alive across GCs:
  return new Uint8Array(100 * 1024);
}

let survivor = allocateSurvivor();

function triggerMinorGC() {
  const junk = [];
  // Allocate lots of short-lived typed‐arrays to fill new‐space:
  for (let i = 0; i < 1e4; i++) {
    junk.push(new Uint8Array(1));  
  }
  // Force a scavenge:
  gc();
}

print("Before any GC: survivor is in new‐space");

triggerMinorGC();
```

