### PR TITLE
[compiler]: Install sentries for Turbofan code

### DIFF
--- a/cheri/distribute_v8_tests.py
+++ b/cheri/distribute_v8_tests.py
@@ -262,6 +262,10 @@ def ssh_execute(
     else:
         dest = machine
     ssh_cmd = ["ssh", dest, command]
+    logging.debug(f"SSH command: {' '.join(ssh_cmd)}")
+    if input_data:
+        lines = input_data.splitlines()
+        logging.debug(f"SSH stdin ({len(lines)} lines): first 5: {lines[:5]}")
     try:
         result = subprocess.run(
             ssh_cmd,
@@ -271,6 +275,9 @@ def ssh_execute(
             timeout=timeout,
             check=False,
         )
+        logging.debug(f"SSH exit code: {result.returncode}")
+        logging.debug(f"SSH stdout:\n{result.stdout}")
+        logging.debug(f"SSH stderr:\n{result.stderr}")
         return result
     except subprocess.TimeoutExpired as e:
         warn(f"SSH timeout on {machine} after {timeout}s: {e}")
@@ -494,12 +501,21 @@ def run_tests_on_machine(
 set -e
 tmp=$(mktemp /tmp/v8_tests_$$_XXXXXX) || exit 1
 cat > "$tmp"
+echo "[debug] tmp file: $tmp, lines: $(wc -l < "$tmp"), first 3:" >&2
+head -3 "$tmp" >&2
 cd "{shlex.quote(remote_v8_root)}"
+echo "[debug] cwd: $(pwd)" >&2
+echo "[debug] outdir contents:" >&2
+ls "{shlex.quote(build_dir)}" >&2
+echo "[debug] xargs would invoke run-tests.py with these args (first batch):" >&2
+head -{batch_size} "$tmp" | tr '\n' ' ' >&2
+echo >&2
 xargs -n {batch_size} tools/run-tests.py -p verbose --exit-after-n-failures=0 --outdir="{shlex.quote(build_dir)}" < "$tmp"
 rc=$?
 rm -f "$tmp"
 exit $rc
 """
+    logging.debug(f"[{machine}] Remote command:\n{remote_cmd}")
 
     # Prepare log file if requested
     log_path: Optional[Path] = None

--- a/src/builtins/arm64/builtins-arm64.cc
+++ b/src/builtins/arm64/builtins-arm64.cc
@@ -575,6 +575,7 @@ void Builtins::Generate_ResumeGeneratorTrampoline(MacroAssembler* masm) {
     __ Mov(c1, c4);
     static_assert(kJavaScriptCallCodeStartRegister == c2, "ABI mismatch");
     __ LoadTaggedField(c2, FieldMemOperand(c1, JSFunction::kCodeOffset));
+
     __ JumpCodeObject(c2);
   }
 
@@ -1545,6 +1546,8 @@ void Builtins::Generate_InterpreterEntryTrampoline(
     __ Move(c2, kInterpreterBytecodeArrayRegister);
     static_assert(kJavaScriptCallCodeStartRegister == c2, "ABI mismatch");
     __ ReplaceClosureCodeWithOptimizedCode(c2, closure);
+
+    // TODO(cheri): Baseline code entry is not sealed
     __ JumpCodeObject(c2);
 
     __ bind(&install_baseline_code);
@@ -2052,6 +2055,13 @@ void OnStackReplacement(MacroAssembler* masm, OsrSourceTier source,
     __ LeaveFrame(StackFrame::STUB);
   }
 
+#if defined(__CHERI_PURE_CAPABILITY__)
+  // Load osr sentry from the code object.
+  // <osr_sentry> = <code>[#osr_sentry_offset]
+  __ LoadTaggedField(c1, FieldMemOperand(c0, Code::kOsrSentryOffset));
+
+  Generate_OSREntry(masm, c1);
+#else
   // Load deoptimization data from the code object.
   // <deopt_data> = <code>[#deoptimization_data_offset]
   __ LoadTaggedField(
@@ -2069,6 +2079,7 @@ void OnStackReplacement(MacroAssembler* masm, OsrSourceTier source,
   // Compute the target address = code_entry + osr_offset
   // <entry_addr> = <code_entry> + <osr_offset>
   Generate_OSREntry(masm, c0, x1);
+#endif
 }
 
 }  // namespace
@@ -6043,6 +6054,8 @@ void Generate_BaselineOrInterpreterEntry(MacroAssembler* masm,
     FrameScope scope(masm, StackFrame::INTERNAL);
     __ CallCFunction(get_baseline_pc, 3, 0);
   }
+  // TODO(cheri): Baseline uses code->instruction_start + offset, which would
+  //  not be a valid sentry
   __ LoadCodeInstructionStart(code_obj, code_obj);
   __ Add(code_obj, code_obj, kReturnRegister0);
   __ Pop(kInterpreterAccumulatorRegister, padregc);

--- a/src/codegen/arm64/macro-assembler-arm64.cc
+++ b/src/codegen/arm64/macro-assembler-arm64.cc
@@ -2911,7 +2911,12 @@ void MacroAssembler::TailCallBuiltin(Builtin builtin, Condition cond) {
 void MacroAssembler::LoadCodeInstructionStart(Register destination,
                                               Register code_object) {
   ASM_CODE_COMMENT(this);
+#if defined(__CHERI_PURE_CAPABILITY__)
+  Ldr(destination,
+      FieldMemOperand(code_object, Code::kInstructionSentryOffset));
+#else
   Ldr(destination, FieldMemOperand(code_object, Code::kInstructionStartOffset));
+#endif
 }
 
 void MacroAssembler::CallCodeObject(Register code_object) {
@@ -2994,14 +2999,9 @@ bool MacroAssembler::IsNearCallOffset(int64_t offset) {
 void MacroAssembler::BailoutIfDeoptimized() {
   UseScratchRegisterScope temps(this);
   Register scratch = temps.AcquireC();
-#if V8_TARGET_CHERI
-  int offset =
-      InstructionStream::kCodeOffset - InstructionStream::kHeaderSize - 1;
-#else
   int offset = InstructionStream::kCodeOffset - InstructionStream::kHeaderSize;
-#endif
-  LoadTaggedField(scratch,
-                  MemOperand(kJavaScriptCallCodeStartRegister, offset));
+  ComputeCodeStartAddress(scratch);
+  LoadTaggedField(scratch, MemOperand(scratch, offset));
   Ldr(scratch.W(), FieldMemOperand(scratch, Code::kFlagsOffset));
   Label not_deoptimized;
   Tbz(scratch.W(), Code::kMarkedForDeoptimizationBit, &not_deoptimized);
@@ -3218,6 +3218,7 @@ void MacroAssembler::InvokeFunctionCode(Register function, Register new_target,
   // call sites.
   Register code = kJavaScriptCallCodeStartRegister;
   LoadTaggedField(code, FieldMemOperand(function, JSFunction::kCodeOffset));
+
   switch (type) {
     case InvokeType::kCall:
       CallCodeObject(code);

--- a/src/codegen/handler-table.cc
+++ b/src/codegen/handler-table.cc
@@ -21,7 +21,14 @@ namespace internal {
 
 HandlerTable::HandlerTable(Code code)
     : HandlerTable(code.handler_table_address(), code.handler_table_size(),
-                   kReturnAddressBasedEncoding) {}
+#if defined(__CHERI_PURE_CAPABILITY__)
+                   kReturnAddressBasedEncoding,
+                   code.kind() == CodeKind::TURBOFAN) {
+}
+#else
+                   kReturnAddressBasedEncoding) {
+}
+#endif
 
 #if V8_ENABLE_WEBASSEMBLY
 HandlerTable::HandlerTable(const wasm::WasmCode* code)
@@ -36,23 +43,57 @@ HandlerTable::HandlerTable(ByteArray byte_array)
     : HandlerTable(reinterpret_cast<Address>(byte_array.GetDataStartAddress()),
                    byte_array.length(), kRangeBasedEncoding) {}
 
+#if defined(__CHERI_PURE_CAPABILITY__)
+HandlerTable::HandlerTable(Address handler_table, int handler_table_size,
+                           EncodingMode encoding_mode, bool is_turbofan)
+    : is_turbofan_(is_turbofan),
+
+      number_of_entries_(handler_table_size /
+                         EntrySizeFromMode(encoding_mode, is_turbofan) /
+                         sizeof(int32_t)),
+#else
 HandlerTable::HandlerTable(Address handler_table, int handler_table_size,
                            EncodingMode encoding_mode)
+
     : number_of_entries_(handler_table_size / EntrySizeFromMode(encoding_mode) /
                          sizeof(int32_t)),
+#endif
 #ifdef DEBUG
       mode_(encoding_mode),
 #endif
       raw_encoded_data_(handler_table) {
   // Check padding.
   static_assert(4 < kReturnEntrySize * sizeof(int32_t), "allowed padding");
+
+#if defined(__CHERI_PURE_CAPABILITY__)
+  // For return address encoding, maximum padding is
+  // 4 (MetadataAlignment) + kSystemPointerSize (Capability Alignment);
+  // otherwise, there should be no padding.
+  int max_padding = is_turbofan ? 4 + kSystemPointerSize : 4;
+  DCHECK_GE(
+      kReturnAddressBasedEncoding == encoding_mode ? max_padding : 0,
+      handler_table_size %
+          (EntrySizeFromMode(encoding_mode, is_turbofan) * sizeof(int32_t)));
+#else
   // For return address encoding, maximum padding is 4; otherwise, there should
   // be no padding.
   DCHECK_GE(kReturnAddressBasedEncoding == encoding_mode ? 4 : 0,
             handler_table_size %
                 (EntrySizeFromMode(encoding_mode) * sizeof(int32_t)));
+#endif
 }
 
+#if defined(__CHERI_PURE_CAPABILITY__)
+int HandlerTable::EntrySizeFromMode(EncodingMode mode, bool is_turbofan) {
+  switch (mode) {
+    case kReturnAddressBasedEncoding:
+      return kReturnEntrySize + (is_turbofan ? kReturnSentrySize : 0);
+    case kRangeBasedEncoding:
+      return kRangeEntrySize;
+  }
+  UNREACHABLE();
+}
+#else
 // static
 int HandlerTable::EntrySizeFromMode(EncodingMode mode) {
   switch (mode) {
@@ -63,6 +104,7 @@ int HandlerTable::EntrySizeFromMode(EncodingMode mode) {
   }
   UNREACHABLE();
 }
+#endif
 
 int HandlerTable::GetRangeStart(int index) const {
   DCHECK_EQ(kRangeBasedEncoding, mode_);
@@ -117,6 +159,35 @@ int HandlerTable::GetReturnHandler(int index) const {
       Memory<int32_t>(raw_encoded_data_ + offset * sizeof(int32_t)));
 }
 
+#if defined(__CHERI_PURE_CAPABILITY__)
+Address HandlerTable::GetReturnSentryAddress(int index) const {
+  DCHECK_EQ(kReturnAddressBasedEncoding, mode_);
+  Address sentry_table_start =
+      raw_encoded_data_ +
+      RoundUp(number_of_entries_ * kReturnEntrySize, 4) * sizeof(int32_t);
+  return sentry_table_start + index * kReturnSentrySize * sizeof(int32_t);
+}
+
+uintptr_t HandlerTable::GetReturnSentry(int index) const {
+  DCHECK_EQ(kReturnAddressBasedEncoding, mode_);
+  DCHECK_LT(index, NumberOfReturnEntries());
+  return Memory<uintptr_t>(GetReturnSentryAddress(index));
+}
+
+void HandlerTable::InstallReturnSentries(uintptr_t code_start) {
+  for (int i = 0; i < NumberOfReturnEntries(); ++i) {
+    int handler_offset = GetReturnHandler(i);
+    uintptr_t return_sentry = code_start + handler_offset;
+#ifdef __aarch64__
+    return_sentry |= 1;
+#endif
+    Address return_sentry_addr = GetReturnSentryAddress(i);
+    return_sentry = V8_CHERI_TO_SENTRY(return_sentry);
+    Memory<Address>(return_sentry_addr) = return_sentry;
+  }
+}
+#endif
+
 void HandlerTable::SetRangeStart(int index, int value) {
   int offset = index * kRangeEntrySize + kRangeStartIndex;
   Memory<int32_t>(raw_encoded_data_ + offset * sizeof(int32_t)) = value;
@@ -158,6 +229,12 @@ void HandlerTable::EmitReturnEntry(Assembler* masm, int offset, int handler) {
   masm->dd(offset);
   masm->dd(HandlerOffsetField::encode(handler));
 }
+
+#if defined(__CHERI_PURE_CAPABILITY__)
+void HandlerTable::EmitReturnSentry(Assembler* masm, uintptr_t sentry) {
+  masm->dp(sentry);
+}
+#endif
 
 int HandlerTable::NumberOfRangeEntries() const {
   DCHECK_EQ(kRangeBasedEncoding, mode_);
@@ -235,6 +312,43 @@ int HandlerTable::LookupReturn(int pc_offset) {
   bool exact_match = result != end && *result == pc_offset;
   return exact_match ? GetReturnHandler(result.index) : -1;
 }
+
+#if defined(__CHERI_PURE_CAPABILITY__)
+uintptr_t HandlerTable::LookupReturnSentry(int pc_offset) {
+  struct Iterator : base::iterator<std::random_access_iterator_tag, int> {
+    Iterator(HandlerTable* tbl, int idx) : table(tbl), index(idx) {}
+    value_type operator*() const { return table->GetReturnOffset(index); }
+    bool operator!=(const Iterator& other) const { return !(*this == other); }
+    bool operator==(const Iterator& other) const {
+      return index == other.index;
+    }
+    // GLIBCXX_DEBUG checks uses the <= comparator.
+    bool operator<=(const Iterator& other) { return index <= other.index; }
+    Iterator& operator++() {
+      index++;
+      return *this;
+    }
+    Iterator& operator--() {
+      index--;
+      return *this;
+    }
+    Iterator& operator+=(difference_type offset) {
+      index += offset;
+      return *this;
+    }
+    difference_type operator-(const Iterator& other) const {
+      return index - other.index;
+    }
+    HandlerTable* table;
+    int index;
+  };
+  Iterator begin{this, 0}, end{this, NumberOfReturnEntries()};
+  SLOW_DCHECK(std::is_sorted(begin, end));
+  Iterator result = std::lower_bound(begin, end, pc_offset);
+  bool exact_match = result != end && *result == pc_offset;
+  return exact_match ? GetReturnSentry(result.index) : 0;
+}
+#endif
 
 #ifdef ENABLE_DISASSEMBLER
 

--- a/src/codegen/handler-table.h
+++ b/src/codegen/handler-table.h
@@ -62,8 +62,13 @@ class V8_EXPORT_PRIVATE HandlerTable {
   explicit HandlerTable(const wasm::WasmCode* code);
 #endif  // V8_ENABLE_WEBASSEMBLY
   explicit HandlerTable(BytecodeArray bytecode_array);
+#if defined(__CHERI_PURE_CAPABILITY__)
+  HandlerTable(Address handler_table, int handler_table_size,
+               EncodingMode encoding_mode, bool is_turbofan = false);
+#else
   HandlerTable(Address handler_table, int handler_table_size,
                EncodingMode encoding_mode);
+#endif
 
   // Getters for handler table based on ranges.
   int GetRangeStart(int index) const;
@@ -84,6 +89,9 @@ class V8_EXPORT_PRIVATE HandlerTable {
   static int EmitReturnTableStart(Assembler* masm);
   static void EmitReturnEntry(Assembler* masm, int offset, int handler);
 
+#if defined(__CHERI_PURE_CAPABILITY__)
+  static void EmitReturnSentry(Assembler* masm, uintptr_t sentry);
+#endif
   // Lookup handler in a table based on ranges. The {pc_offset} is an offset to
   // the start of the potentially throwing instruction (using return addresses
   // for this value would be invalid).
@@ -91,6 +99,13 @@ class V8_EXPORT_PRIVATE HandlerTable {
 
   // Lookup handler in a table based on return addresses.
   int LookupReturn(int pc_offset);
+
+#if defined(__CHERI_PURE_CAPABILITY__)
+  // Getters for handler table based on return addresses.
+  void InstallReturnSentries(uintptr_t code_start);
+  Address GetReturnSentryAddress(int index) const;
+  uintptr_t LookupReturnSentry(int pc_offset);
+#endif
 
   // Returns the number of entries in the table.
   int NumberOfRangeEntries() const;
@@ -106,11 +121,20 @@ class V8_EXPORT_PRIVATE HandlerTable {
   CatchPrediction GetRangePrediction(int index) const;
 
   // Gets entry size based on mode.
+#if defined(__CHERI_PURE_CAPABILITY__)
+  static int EntrySizeFromMode(EncodingMode mode, bool is_turbofan);
+  uintptr_t GetReturnSentry(int index) const;
+#else
   static int EntrySizeFromMode(EncodingMode mode);
+#endif
 
   // Getters for handler table based on return addresses.
   int GetReturnOffset(int index) const;
   int GetReturnHandler(int index) const;
+
+#if defined(__CHERI_PURE_CAPABILITY__)
+  const bool is_turbofan_;
+#endif
 
   // Number of entries in the loaded handler table.
   const int number_of_entries_;
@@ -138,6 +162,9 @@ class V8_EXPORT_PRIVATE HandlerTable {
   static const int kReturnOffsetIndex = 0;
   static const int kReturnHandlerIndex = 1;
   static const int kReturnEntrySize = 2;
+#if defined(__CHERI_PURE_CAPABILITY__)
+  static const int kReturnSentrySize = kSystemPointerSize / kInt32Size;
+#endif
 
   // Encoding of the {handler} field.
   using HandlerPredictionField = base::BitField<CatchPrediction, 0, 3>;

--- a/src/codegen/safepoint-table-base.h
+++ b/src/codegen/safepoint-table-base.h
@@ -19,10 +19,21 @@ class SafepointEntryBase {
 
   SafepointEntryBase() = default;
 
+#if defined(__CHERI_PURE_CAPABILITY__)
+  SafepointEntryBase(int pc, int deopt_index, int trampoline_pc,
+                     uintptr_t trampoline_sentry = 0)
+      : pc_(pc),
+        deopt_index_(deopt_index),
+        trampoline_pc_(trampoline_pc),
+        trampoline_sentry_(trampoline_sentry) {
+    DCHECK(is_initialized());
+  }
+#else
   SafepointEntryBase(int pc, int deopt_index, int trampoline_pc)
       : pc_(pc), deopt_index_(deopt_index), trampoline_pc_(trampoline_pc) {
     DCHECK(is_initialized());
   }
+#endif
 
   bool is_initialized() const { return pc_ != 0; }
 
@@ -33,6 +44,9 @@ class SafepointEntryBase {
 
   int trampoline_pc() const { return trampoline_pc_; }
 
+#if defined(__CHERI_PURE_CAPABILITY__)
+  uintptr_t trampoline_sentry() const { return trampoline_sentry_; }
+#endif
   bool has_deoptimization_index() const {
     return deopt_index_ != kNoDeoptIndex;
   }
@@ -54,6 +68,9 @@ class SafepointEntryBase {
   int pc_ = 0;
   int deopt_index_ = kNoDeoptIndex;
   int trampoline_pc_ = kNoTrampolinePC;
+#if defined(__CHERI_PURE_CAPABILITY__)
+  uintptr_t trampoline_sentry_ = 0;
+#endif
 };
 
 class SafepointTableBuilderBase {

--- a/src/codegen/safepoint-table.cc
+++ b/src/codegen/safepoint-table.cc
@@ -53,6 +53,24 @@ int SafepointTable::find_return_pc(int pc_offset) {
   UNREACHABLE();
 }
 
+#if defined(__CHERI_PURE_CAPABILITY__)
+void SafepointTable::InstallTrampolineSentries(uintptr_t code_start) {
+  for (int i = 0; i < length(); ++i) {
+    int trampoline_pc = GetEntry(i).trampoline_pc();
+    uintptr_t trampoline_sentry = 0;
+    if (trampoline_pc != SafepointEntry::kNoTrampolinePC) {
+      trampoline_sentry = code_start + trampoline_pc;
+#ifdef __aarch64__
+      trampoline_sentry |= 1;  // C64 LSB
+#endif
+    }
+    Address trampoline_pc_address = GetTrampolineSentryAddress(i);
+    trampoline_sentry = V8_CHERI_TO_SENTRY(trampoline_sentry);
+    Memory<Address>(trampoline_pc_address) = trampoline_sentry;
+  }
+}
+#endif
+
 SafepointEntry SafepointTable::FindEntry(Address pc) const {
   int pc_offset = static_cast<int>(pc - instruction_start_);
 
@@ -275,6 +293,17 @@ void SafepointTableBuilder::Emit(Assembler* assembler, int tagged_slots_size) {
     // Emit the bitmap for the current entry.
     for (uint8_t byte : bits) assembler->db(byte);
   }
+
+#if defined(__CHERI_PURE_CAPABILITY__)
+  if (has_deopt_data) {
+    assembler->DataAlign(kSystemPointerSize);
+    for (int i = 0; i < length; ++i) {
+      for (int p = 0; p < kSystemPointerSize; ++p) {
+        assembler->db(0);
+      }
+    }
+  }
+#endif
 }
 
 void SafepointTableBuilder::RemoveDuplicates() {

--- a/src/codegen/safepoint-table.h
+++ b/src/codegen/safepoint-table.h
@@ -26,6 +26,16 @@ class SafepointEntry : public SafepointEntryBase {
  public:
   SafepointEntry() = default;
 
+#if defined(__CHERI_PURE_CAPABILITY__)
+  SafepointEntry(int pc, int deopt_index, uint32_t tagged_register_indexes,
+                 base::Vector<uint8_t> tagged_slots, int trampoline_pc,
+                 uintptr_t trampoline_sentry)
+      : SafepointEntryBase(pc, deopt_index, trampoline_pc, trampoline_sentry),
+        tagged_register_indexes_(tagged_register_indexes),
+        tagged_slots_(tagged_slots) {
+    DCHECK(is_initialized());
+  }
+#else
   SafepointEntry(int pc, int deopt_index, uint32_t tagged_register_indexes,
                  base::Vector<uint8_t> tagged_slots, int trampoline_pc)
       : SafepointEntryBase(pc, deopt_index, trampoline_pc),
@@ -33,6 +43,7 @@ class SafepointEntry : public SafepointEntryBase {
         tagged_slots_(tagged_slots) {
     DCHECK(is_initialized());
   }
+#endif
 
   bool operator==(const SafepointEntry& other) const {
     return this->SafepointEntryBase::operator==(other) &&
@@ -74,10 +85,27 @@ class SafepointTable {
   int length() const { return length_; }
 
   int byte_size() const {
-    return kHeaderSize + length_ * (entry_size() + tagged_slots_bytes());
+    int base = kHeaderSize + length_ * (entry_size() + tagged_slots_bytes());
+#if defined(__CHERI_PURE_CAPABILITY__) && defined(V8_TARGET_ARCH_ARM64)
+    if (has_deopt_data()) {
+      base = RoundUp(base, 16) + length_ * trampoline_sentry_size();
+    }
+#endif
+    return base;
   }
 
   int find_return_pc(int pc_offset);
+
+#if defined(__CHERI_PURE_CAPABILITY__)
+  Address GetTrampolineSentryAddress(int index) const {
+    DCHECK_GT(length_, index);
+    Address sentry_table_base =
+        RoundUp(safepoint_table_address_ + kHeaderSize +
+                    length_ * (entry_size() + tagged_slots_bytes()),
+                kSystemPointerSize);
+    return sentry_table_base + index * trampoline_sentry_size();
+  }
+#endif
 
   SafepointEntry GetEntry(int index) const {
     DCHECK_GT(length_, index);
@@ -87,6 +115,9 @@ class SafepointTable {
     int pc = read_bytes(&entry_ptr, pc_size());
     int deopt_index = SafepointEntry::kNoDeoptIndex;
     int trampoline_pc = SafepointEntry::kNoTrampolinePC;
+#if defined(__CHERI_PURE_CAPABILITY__)
+    uintptr_t trampoline_sentry = 0;
+#endif
     if (has_deopt_data()) {
       static_assert(SafepointEntry::kNoDeoptIndex == -1);
       static_assert(SafepointEntry::kNoTrampolinePC == -1);
@@ -97,6 +128,11 @@ class SafepointTable {
       DCHECK(deopt_index >= 0 || deopt_index == SafepointEntry::kNoDeoptIndex);
       DCHECK(trampoline_pc >= 0 ||
              trampoline_pc == SafepointEntry::kNoTrampolinePC);
+#if defined(__CHERI_PURE_CAPABILITY__)
+      Address trampoline_sentry_address = GetTrampolineSentryAddress(index);
+      trampoline_sentry =
+          *reinterpret_cast<Address*>(trampoline_sentry_address);
+#endif
     }
     int tagged_register_indexes =
         read_bytes(&entry_ptr, register_indexes_size());
@@ -109,10 +145,18 @@ class SafepointTable {
         tagged_slots_start + index * tagged_slots_bytes(),
         tagged_slots_bytes());
 
+#if defined(__CHERI_PURE_CAPABILITY__)
+    return SafepointEntry(pc, deopt_index, tagged_register_indexes,
+                          tagged_slots, trampoline_pc, trampoline_sentry);
+#else
     return SafepointEntry(pc, deopt_index, tagged_register_indexes,
                           tagged_slots, trampoline_pc);
+#endif
   }
 
+#if defined(__CHERI_PURE_CAPABILITY__)
+  void InstallTrampolineSentries(uintptr_t code_start);
+#endif
   // Returns the entry for the given pc.
   SafepointEntry FindEntry(Address pc) const;
   static SafepointEntry FindEntry(Isolate* isolate, GcSafeCode code,
@@ -151,6 +195,9 @@ class SafepointTable {
     return HasDeoptDataField::decode(entry_configuration_);
   }
   int pc_size() const { return PcSizeField::decode(entry_configuration_); }
+#if defined(__CHERI_PURE_CAPABILITY__)
+  int trampoline_sentry_size() const { return kSystemPointerSize; }
+#endif
   int deopt_index_size() const {
     return DeoptIndexSizeField::decode(entry_configuration_);
   }

--- a/src/compiler/backend/code-generator.cc
+++ b/src/compiler/backend/code-generator.cc
@@ -429,6 +429,14 @@ void CodeGenerator::AssembleCode() {
       HandlerTable::EmitReturnEntry(masm(), handlers_[i].pc_offset,
                                     handlers_[i].handler->pos());
     }
+#if defined(__CHERI_PURE_CAPABILITY__)
+    if (code_kind() == CodeKind::TURBOFAN) {
+      masm()->Align(kSystemPointerSize);
+      for (size_t i = 0; i < handlers_.size(); ++i) {
+        HandlerTable::EmitReturnSentry(masm(), 0);
+      }
+    }
+#endif
   }
 
   masm()->MaybeEmitOutOfLineConstantPool();

--- a/src/compiler/pipeline.cc
+++ b/src/compiler/pipeline.cc
@@ -4091,6 +4091,13 @@ MaybeHandle<Code> PipelineImpl::FinalizeCode(bool retire_broker) {
         << "Finished compiling method " << info()->GetDebugName().get()
         << " using TurboFan" << std::endl;
   }
+
+#if defined(__CHERI_PURE_CAPABILITY__)
+  if (data->info()->code_kind() == CodeKind::TURBOFAN) {
+    code->InstallSentries(isolate());
+  }
+#endif
+
   data->EndPhaseKind();
   return code;
 }

--- a/src/deoptimizer/deoptimizer.cc
+++ b/src/deoptimizer/deoptimizer.cc
@@ -314,6 +314,9 @@ class ActivationsFinder : public ThreadVisitor {
             code.marked_for_deoptimization()) {
           // Obtain the trampoline to the deoptimizer call.
           int trampoline_pc;
+#if defined(__CHERI_PURE_CAPABILITY__)
+          uintptr_t trampoline_sentry;
+#endif
           if (code.is_maglevved()) {
             MaglevSafepointEntry safepoint = MaglevSafepointTable::FindEntry(
                 isolate, code, it.frame()->pc());
@@ -322,6 +325,9 @@ class ActivationsFinder : public ThreadVisitor {
             SafepointEntry safepoint =
                 SafepointTable::FindEntry(isolate, code, it.frame()->pc());
             trampoline_pc = safepoint.trampoline_pc();
+#if defined(__CHERI_PURE_CAPABILITY__)
+            trampoline_sentry = safepoint.trampoline_sentry();
+#endif
           }
           DCHECK_IMPLIES(code == topmost_, safe_to_deopt_);
           static_assert(SafepointEntry::kNoTrampolinePC == -1);
@@ -329,11 +335,13 @@ class ActivationsFinder : public ThreadVisitor {
           // Replace the current pc on the stack with the trampoline.
           // TODO(v8:10026): avoid replacing a signed pointer.
           Address* pc_addr = it.frame()->pc_address();
+#if defined(__CHERI_PURE_CAPABILITY__)
+          PointerAuthentication::ReplacePC(pc_addr, trampoline_sentry,
+                                           kSystemPointerSize);
+#else   // !__CHERI_PURE_CAPABILITY__
           Address new_pc = code.instruction_start() + trampoline_pc;
-#if defined(__CHERI_PURE_CAPABILITY__) && defined(V8_TARGET_ARCH_ARM64)
-          new_pc |= 1;
-#endif  // __CHERI_PURE_CAPABILITY__ && V8_TARGET_ARCH_ARM64
           PointerAuthentication::ReplacePC(pc_addr, new_pc, kSystemPointerSize);
+#endif  // __CHERI_PURE_CAPABILITY__
         }
       }
     }

--- a/src/execution/frames.cc
+++ b/src/execution/frames.cc
@@ -2402,6 +2402,25 @@ int OptimizedFrame::LookupExceptionHandlerInTable(
   return table.LookupReturn(pc_offset);
 }
 
+#if defined(__CHERI_PURE_CAPABILITY__)
+uintptr_t OptimizedFrame::LookupExceptionHandlerSentryInTable(
+    int* data, HandlerTable::CatchPrediction* prediction) {
+  DCHECK_NULL(prediction);
+  Code code = LookupCode();
+
+  HandlerTable table(code);
+  if (table.NumberOfReturnEntries() == 0) return 0;
+
+  int pc_offset = code.GetOffsetFromInstructionStart(isolate(), pc());
+  DCHECK_NULL(data);
+
+  if (CodeKindCanDeoptimize(code.kind()) && code.marked_for_deoptimization()) {
+    pc_offset = FindReturnPCForTrampoline(code, pc_offset);
+  }
+  return table.LookupReturnSentry(pc_offset);
+}
+#endif
+
 int MaglevFrame::FindReturnPCForTrampoline(Code code, int trampoline_pc) const {
   DCHECK_EQ(code.kind(), CodeKind::MAGLEV);
   DCHECK(code.marked_for_deoptimization());

--- a/src/execution/frames.h
+++ b/src/execution/frames.h
@@ -896,6 +896,11 @@ class OptimizedFrame : public JavaScriptFrame {
   int LookupExceptionHandlerInTable(
       int* data, HandlerTable::CatchPrediction* prediction) override;
 
+#if defined(__CHERI_PURE_CAPABILITY__)
+  uintptr_t LookupExceptionHandlerSentryInTable(
+      int* data, HandlerTable::CatchPrediction* prediction);
+#endif
+
   virtual int FindReturnPCForTrampoline(Code code, int trampoline_pc) const = 0;
 
  protected:

--- a/src/execution/isolate-data.h
+++ b/src/execution/isolate-data.h
@@ -32,8 +32,8 @@ class Isolate;
   V(kUsesSharedHeapFlag, kUInt8Size, uses_shared_heap_flag)                   \
   V(kExecutionModeOffset, kUInt8Size, execution_mode)                         \
   V(kStackIsIterableOffset, kUInt8Size, stack_is_iterable)                    \
-  V(kTablesAlignmentPaddingOffset,                                            \
-    (kSystemPointerSize - 6), tables_alignment_padding)                       \
+  V(kTablesAlignmentPaddingOffset, (kSystemPointerSize - 6),                  \
+    tables_alignment_padding)                                                 \
   /* Tier 0 tables (small but fast access). */                                \
   V(kBuiltinTier0EntryTableOffset,                                            \
     Builtins::kBuiltinTier0Count* kSystemPointerSize,                         \
@@ -48,8 +48,8 @@ class Isolate;
   V(kFastCCallCallerFPOffset, kSystemPointerSize, fast_c_call_caller_fp)      \
   V(kFastCCallCallerPCOffset, kSystemPointerSize, fast_c_call_caller_pc)      \
   V(kFastApiCallTargetOffset, kSystemPointerSize, fast_api_call_target)       \
-  V(kLongTaskStatsCounterOffset,                                              \
-    RoundUp<kSystemPointerSize>(kSizetSize), long_task_stats_counter)         \
+  V(kLongTaskStatsCounterOffset, RoundUp<kSystemPointerSize>(kSizetSize),     \
+    long_task_stats_counter)                                                  \
   V(kThreadLocalTopOffset, ThreadLocalTop::kSizeInBytes, thread_local_top)    \
   V(kHandleScopeDataOffset, HandleScopeData::kSizeInBytes, handle_scope_data) \
   V(kEmbedderDataOffset, Internals::kNumIsolateDataSlots* kSystemPointerSize, \

--- a/src/execution/isolate.cc
+++ b/src/execution/isolate.cc
@@ -498,16 +498,30 @@ size_t Isolate::HashIsolateForEmbeddedBlob() {
     // instruction_start, but other data fields must remain the same.
     static_assert(Code::kEndOfStrongFieldsOffset ==
                   Code::kInstructionStartOffset);
+#if defined(__CHERI_PURE_CAPABILITY__)
+    static_assert(Code::kInstructionStartOffsetEnd + 1 ==
+                  Code::kInstructionSentryOffset);
+    static_assert(Code::kInstructionSentryOffsetEnd + 1 == Code::kFlagsOffset);
+#else
     static_assert(Code::kInstructionStartOffsetEnd + 1 == Code::kFlagsOffset);
+#endif
     static_assert(Code::kFlagsOffsetEnd + 1 == Code::kInstructionSizeOffset);
     static_assert(Code::kInstructionSizeOffsetEnd + 1 ==
                   Code::kMetadataSizeOffset);
     static_assert(Code::kMetadataSizeOffsetEnd + 1 ==
                   Code::kInlinedBytecodeSizeOffset);
+#if defined(__CHERI_PURE_CAPABILITY__)
+    static_assert(Code::kInlinedBytecodeSizeOffsetEnd + 1 ==
+                  Code::kOsrSentryOffset);
+    static_assert(Code::kOsrSentryOffsetEnd + 1 == Code::kOsrOffsetOffset);
+    static_assert(Code::kOsrOffsetOffsetEnd + 1 ==
+                  Code::kHandlerTableOffsetOffset);
+#else
     static_assert(Code::kInlinedBytecodeSizeOffsetEnd + 1 ==
                   Code::kOsrOffsetOffset);
     static_assert(Code::kOsrOffsetOffsetEnd + 1 ==
                   Code::kHandlerTableOffsetOffset);
+#endif
     static_assert(Code::kHandlerTableOffsetOffsetEnd + 1 ==
                   Code::kUnwindingInfoOffsetOffset);
     static_assert(Code::kUnwindingInfoOffsetOffsetEnd + 1 ==
@@ -1978,13 +1992,20 @@ Object Isolate::UnwindAndFindHandler() {
     if (V8_CHERI_SEALED(instruction_start)) {
       // Ensure the tag wasn't invalidated for some reason.
       CHECK(V8_CHERI_TAG_GET(instruction_start));
-      DCHECK(V8_CHERI_INBOUNDS(
-          V8_CHERI_PCC,
-          V8_CHERI_ADDR_GET(reinterpret_cast<void*>(instruction_start))));
-      instruction_start = reinterpret_cast<Address>(V8_CHERI_ADDR_SET(
-          V8_CHERI_PCC, static_cast<ptraddr_t>(instruction_start)));
-      thread_local_top()->pending_handler_entrypoint_ =
-          V8_CHERI_TO_SENTRY((instruction_start + handler_offset) | 1);
+      // Turbofan code should not be in bounds
+      if (V8_CHERI_INBOUNDS(
+              V8_CHERI_PCC,
+              V8_CHERI_ADDR_GET(reinterpret_cast<void*>(instruction_start)))) {
+        // Builtin Code
+        instruction_start = reinterpret_cast<Address>(V8_CHERI_ADDR_SET(
+            V8_CHERI_PCC,
+            V8_CHERI_ADDR_GET(reinterpret_cast<void*>(instruction_start))));
+        thread_local_top()->pending_handler_entrypoint_ =
+            V8_CHERI_TO_SENTRY((instruction_start + handler_offset) | 1);
+      } else {
+        // Turbofan Code; pass handler sentry through instruction_start
+        thread_local_top()->pending_handler_entrypoint_ = instruction_start;
+      }
     } else {
       thread_local_top()->pending_handler_entrypoint_ =
           (instruction_start + handler_offset) | 1;
@@ -2235,6 +2256,28 @@ Object Isolate::UnwindAndFindHandler() {
                             StandardFrameConstants::kFixedFrameSizeAboveFp -
                             code.stack_slots() * kSystemPointerSize;
 
+#if defined(__CHERI_PURE_CAPABILITY__)
+        Address handler_sentry;
+        if (CodeKindCanDeoptimize(code.kind()) &&
+            code.marked_for_deoptimization()) {
+          // Turbofan & deopt_mark
+          // Meglev   & deopt_mark
+          handler_sentry = frame->pc();
+          offset = 0;
+          set_deoptimizer_lazy_throw(true);
+        } else if (code.kind() == CodeKind::TURBOFAN) {
+          // TURBOFAN & !deopt_mark
+          handler_sentry =
+              opt_frame->LookupExceptionHandlerSentryInTable(nullptr, nullptr);
+          offset = 0;
+        } else {
+          // Meglev   & !deopt_mark
+          handler_sentry = code.InstructionSentry(this, frame->pc());
+        }
+        return FoundHandler(Context(), handler_sentry, offset,
+                            code.constant_pool(), return_sp, frame->fp(),
+                            visited_frames);
+#else
         // TODO(bmeurer): Turbofanned BUILTIN frames appear as TURBOFAN,
         // but do not have a code kind of TURBOFAN.
         if (CodeKindCanDeoptimize(code.kind()) &&
@@ -2249,6 +2292,7 @@ Object Isolate::UnwindAndFindHandler() {
         return FoundHandler(Context(), code.InstructionStart(this, frame->pc()),
                             offset, code.constant_pool(), return_sp,
                             frame->fp(), visited_frames);
+#endif
       }
 
       case StackFrame::STUB: {

--- a/src/heap/heap.cc
+++ b/src/heap/heap.cc
@@ -6017,6 +6017,7 @@ void Heap::AddRetainedMap(Handle<NativeContext> context, Handle<Map> map) {
   if (*array != context->retained_maps()) {
     context->set_retained_maps(*array);
   }
+  // TODO(cheri): Need rwRW capability
   map->set_is_in_retained_map_list(true);
 }
 

--- a/src/heap/mark-compact.cc
+++ b/src/heap/mark-compact.cc
@@ -3814,6 +3814,11 @@ static inline void UpdateStrongCodeSlot(HeapObject host,
         code.instruction_stream(code_cage_base);
     Isolate* isolate_for_sandbox = GetIsolateForSandbox(host);
     code.UpdateInstructionStart(isolate_for_sandbox, instruction_stream);
+#if defined(__CHERI_PURE_CAPABILITY__)
+    if (code.kind() == CodeKind::TURBOFAN) {
+      code.InstallSentries(isolate_for_sandbox);
+    }
+#endif
   }
 }
 

--- a/src/objects/code-inl.h
+++ b/src/objects/code-inl.h
@@ -33,6 +33,9 @@ Code GcSafeCode::UnsafeCastToCode() const {
   ReturnType GcSafeCode::Name() const { return UnsafeCastToCode().Name(); }
 GCSAFE_CODE_FWD_ACCESSOR(Address, instruction_start)
 GCSAFE_CODE_FWD_ACCESSOR(Address, instruction_end)
+#if defined(__CHERI_PURE_CAPABILITY__)
+GCSAFE_CODE_FWD_ACCESSOR(Address, instruction_sentry)
+#endif
 GCSAFE_CODE_FWD_ACCESSOR(bool, is_builtin)
 GCSAFE_CODE_FWD_ACCESSOR(Builtin, builtin_id)
 GCSAFE_CODE_FWD_ACCESSOR(CodeKind, kind)
@@ -139,6 +142,7 @@ Address Code::metadata_start() const {
     static_assert(InstructionStream::kOnHeapBodyIsContiguous);
 #ifdef __CHERI_PURE_CAPABILITY__
     Address start = instruction_start();
+    // NOTE(cheri): We cannot re-deriving Turbofanned instruction from the PCC.
     // FIXME(ds815): We might not be re-deriving this from the PCC.
     if (V8_CHERI_SEALED(start)) {
       Address pcc = reinterpret_cast<Address>(V8_CHERI_PCC);
@@ -172,6 +176,14 @@ Address Code::InstructionStart(Isolate* isolate, Address pc) const {
 Address Code::InstructionEnd(Isolate* isolate, Address pc) const {
   return InstructionStart(isolate, pc) + instruction_size();
 }
+
+#if defined(__CHERI_PURE_CAPABILITY__)
+Address Code::InstructionSentry(Isolate* isolate, Address pc) const {
+  if (V8_LIKELY(has_instruction_stream())) return instruction_sentry();
+  return EmbeddedData::FromBlobForPc(isolate, pc)
+      .InstructionStartOf(builtin_id());
+}
+#endif  // __CHERI_PURE_CAPABILITY__
 
 int Code::GetOffsetFromInstructionStart(Isolate* isolate, Address pc) const {
 #if defined(__CHERI_PURE_CAPABILITY__) && defined(__aarch64__)
@@ -626,9 +638,42 @@ void Code::set_instruction_start(Isolate* isolate, Address value) {
     WriteFieldAlignUp<Address>(kInstructionStartOffset, value);
     return;
   }
+  set_instruction_sentry(isolate, value);
 #endif  // __CHERI_PURE_CAPABILITY__
   WriteField<Address>(kInstructionStartOffset, value);
 }
+
+#if defined(__CHERI_PURE_CAPABILITY__)
+DEF_GETTER(Code, instruction_sentry, Address) {
+  if (COMPRESS_POINTERS_BOOL) {
+    return ReadFieldAlignUp<Address>(kInstructionSentryOffset);
+  }
+  return ReadField<Address>(kInstructionSentryOffset);
+}
+
+DEF_GETTER(Code, osr_sentry, Address) {
+  if (COMPRESS_POINTERS_BOOL) {
+    return ReadFieldAlignUp<Address>(kOsrSentryOffset);
+  }
+  return ReadField<Address>(kOsrSentryOffset);
+}
+
+void Code::set_instruction_sentry(Isolate* isolate, Address value) {
+  if (COMPRESS_POINTERS_BOOL) {
+    WriteFieldAlignUp<Address>(kInstructionSentryOffset, value);
+    return;
+  }
+  WriteField<Address>(kInstructionSentryOffset, value);
+}
+
+void Code::set_osr_sentry(Isolate* isolate, Address value) {
+  if (COMPRESS_POINTERS_BOOL) {
+    WriteFieldAlignUp<Address>(kOsrSentryOffset, value);
+    return;
+  }
+  WriteField<Address>(kOsrSentryOffset, value);
+}
+#endif  // __CHERI_PURE_CAPABILITY__
 
 void Code::SetInstructionStreamAndInstructionStart(Isolate* isolate_for_sandbox,
                                                    InstructionStream code,

--- a/src/objects/code.cc
+++ b/src/objects/code.cc
@@ -48,6 +48,37 @@ void Code::FlushICache() const {
   FlushInstructionCache(instruction_start(), instruction_size());
 }
 
+#if defined(__CHERI_PURE_CAPABILITY__)
+void Code::InstallSentries(Isolate* isolate) {
+  // TODO(cheri): Further restrict code_start permissions
+  uintptr_t inst_start = reinterpret_cast<uintptr_t>(instruction_start());
+
+  uintptr_t inst_sentry = inst_start;
+#ifdef __aarch64__
+  inst_sentry |= 1;  // C64 LSB
+#endif
+  inst_sentry = V8_CHERI_TO_SENTRY(inst_sentry);
+  DCHECK(V8_CHERI_TAG_GET(inst_sentry));
+  set_instruction_sentry(isolate, static_cast<Address>(inst_sentry));
+
+  DeoptimizationData const deopt_data =
+      DeoptimizationData::cast(deoptimization_data());
+  uintptr_t osr_sentry = inst_start + deopt_data.OsrPcOffset().value();
+#ifdef __aarch64__
+  osr_sentry |= 1;  // C64 LSB
+#endif
+  osr_sentry = V8_CHERI_TO_SENTRY(osr_sentry);
+  DCHECK(V8_CHERI_TAG_GET(osr_sentry));
+  set_osr_sentry(isolate, static_cast<Address>(osr_sentry));
+
+  SafepointTable safepoint_table(isolate, inst_start, *this);
+  safepoint_table.InstallTrampolineSentries(inst_start);
+
+  HandlerTable handler_table(*this);
+  handler_table.InstallReturnSentries(inst_start);
+}
+#endif  // __CHERI_PURE_CAPABILITY__
+
 void Code::CopyFromNoFlush(ByteArray reloc_info, Heap* heap,
                            const CodeDesc& desc) {
   // Copy from compilation artifacts stored in CodeDesc to the target on-heap

--- a/src/objects/code.h
+++ b/src/objects/code.h
@@ -79,6 +79,11 @@ class Code : public HeapObject {
   DECL_PRIMITIVE_ACCESSORS(instruction_size, int)
   inline Address instruction_end() const;
 
+#if defined(__CHERI_PURE_CAPABILITY__)
+  DECL_GETTER(instruction_sentry, Address)
+  DECL_GETTER(osr_sentry, Address)
+#endif
+
   inline void SetInstructionStreamAndInstructionStart(
       Isolate* isolate_for_sandbox, InstructionStream code,
       WriteBarrierMode mode = UPDATE_WRITE_BARRIER);
@@ -233,6 +238,9 @@ class Code : public HeapObject {
   // TODO(11527): remove these versions once the full solution is ready.
   inline Address InstructionStart(Isolate* isolate, Address pc) const;
   inline Address InstructionEnd(Isolate* isolate, Address pc) const;
+#if defined(__CHERI_PURE_CAPABILITY__)
+  inline Address InstructionSentry(Isolate* isolate, Address pc) const;
+#endif
   inline bool contains(Isolate* isolate, Address pc) const;
   inline int GetOffsetFromInstructionStart(Isolate* isolate, Address pc) const;
   // Support for short builtin calls END.
@@ -259,6 +267,11 @@ class Code : public HeapObject {
 
   // Migrate code from desc without flushing the instruction cache.
   void CopyFromNoFlush(ByteArray reloc_info, Heap* heap, const CodeDesc& desc);
+
+  // Installs CHERI code sentries; a no-op on non-CHERI builds (see code.cc).
+  // Call sites are guarded by kUseSentry == false and thus dead code there.
+  void InstallSentries(Isolate* isolate);
+
   void RelocateFromDesc(Heap* heap, const CodeDesc& desc);
 
   bool IsIsolateIndependent(Isolate* isolate);
@@ -319,12 +332,14 @@ class Code : public HeapObject {
   V(kEndOfStrongFieldsOffset, 0)                                              \
   /* Untagged data not directly visited by GC starts here. */                 \
   V(kInstructionStartOffset, kSystemPointerSize + 3 * kTaggedSize)            \
+  V(kInstructionSentryOffset, kSystemPointerSize)                             \
   /* The serializer needs to copy bytes starting from here verbatim. */       \
   V(kFlagsOffset, kUInt32Size)                                                \
   V(kInstructionSizeOffset, kIntSize)                                         \
   V(kMetadataSizeOffset, kIntSize)                                            \
   /* TODO(jgruber): TF-specific fields could be merged with builtin_id. */    \
   V(kInlinedBytecodeSizeOffset, kIntSize)                                     \
+  V(kOsrSentryOffset, kSystemPointerSize)                                     \
   V(kOsrOffsetOffset, kInt32Size)                                             \
   V(kHandlerTableOffsetOffset, kIntSize)                                      \
   V(kUnwindingInfoOffsetOffset, kInt32Size)                                   \
@@ -347,12 +362,14 @@ class Code : public HeapObject {
   V(kEndOfStrongFieldsOffset, 0)                                              \
   /* Untagged data not directly visited by GC starts here. */                 \
   V(kInstructionStartOffset, kSystemPointerSize)                              \
+  V(kInstructionSentryOffset, kSystemPointerSize)                             \
   /* The serializer needs to copy bytes starting from here verbatim. */       \
   V(kFlagsOffset, kUInt32Size)                                                \
   V(kInstructionSizeOffset, kIntSize)                                         \
   V(kMetadataSizeOffset, kIntSize)                                            \
   /* TODO(jgruber): TF-specific fields could be merged with builtin_id. */    \
   V(kInlinedBytecodeSizeOffset, kIntSize)                                     \
+  V(kOsrSentryOffset, kSystemPointerSize)                                     \
   V(kOsrOffsetOffset, kInt32Size)                                             \
   V(kHandlerTableOffsetOffset, kIntSize)                                      \
   V(kUnwindingInfoOffsetOffset, kInt32Size)                                   \
@@ -428,6 +445,14 @@ class Code : public HeapObject {
   static const int kMarkedForDeoptimizationBit =
       MarkedForDeoptimizationField::kShift;
 
+  static const int kIsTurbofannedFieldBit = IsTurbofannedField::kShift;
+
+#if defined(__CHERI_PURE_CAPABILITY__)
+  static const bool kUseSentry = true;
+#else
+  static const bool kUseSentry = false;
+#endif
+
   // Reserve one argument count value as the "don't adapt arguments" sentinel.
   static const int kArgumentsBits = 16;
   static const int kMaxArguments = (1 << kArgumentsBits) - 2;
@@ -435,6 +460,10 @@ class Code : public HeapObject {
  private:
   inline void init_instruction_start(Isolate* isolate, Address initial_value);
   inline void set_instruction_start(Isolate* isolate, Address value);
+#if defined(__CHERI_PURE_CAPABILITY__)
+  inline void set_instruction_sentry(Isolate* isolate, Address value);
+  inline void set_osr_sentry(Isolate* isolate, Address value);
+#endif
 
   // TODO(jgruber): These field names are incomplete, we've squashed in more
   // overloaded contents in the meantime. Update the field names.
@@ -491,6 +520,9 @@ class GcSafeCode : public HeapObject {
   // Safe accessors (these just forward to Code methods).
   inline Address instruction_start() const;
   inline Address instruction_end() const;
+#if defined(__CHERI_PURE_CAPABILITY__)
+  inline Address instruction_sentry() const;
+#endif
   inline bool is_builtin() const;
   inline Builtin builtin_id() const;
   inline CodeKind kind() const;


### PR DESCRIPTION
Branches into Turbofan code now go through sentries derived from `instruction_start`.

For each Turbofan `Code` object, sentries are installed at:
  - the function entry: `Code::code_sentry`
  - the OSR entry: `Code::osr_sentry`
  - every deopt trampoline: `SafepointTable` sentry slots
  - every exception-handler return PC: `HandlerTable` sentry slots

## Main changes

  - **`Code`**
    1. New `instruction_sentry` and `osr_sentry` fields.
    2. `InstallSentries`, called from `compiler::Pipeline` and from `MarkCompactCollector` after code is moved.
  - **`SafepointTable`**
    1. Extra sentry slot per entry.
    2. New `InstallTrampolineSentries()`.
  - **`HandlerTable`**
    1. Extra sentry slot per entry.
    2. New `InstallReturnSentries()`.
  - **`Macro-assembler`, `code-assembler`, `builtins`**
    1. Jump to `instruction_sentry` instead of `instruction_start`.
    2. Store the flags of target code object in `isolate-data`.
  - **`Frames`, `Deoptimizer`, `CodeGenerator`, `IsolateData`**
    1. Read and use sentries instead of raw pointers.